### PR TITLE
Update QuickStartImageExampleActivity.java

### DIFF
--- a/QiniuLab/app/src/main/java/com/qiniu/qiniulab/activity/quick/QuickStartImageExampleActivity.java
+++ b/QiniuLab/app/src/main/java/com/qiniu/qiniulab/activity/quick/QuickStartImageExampleActivity.java
@@ -155,7 +155,26 @@ public class QuickStartImageExampleActivity extends ActionBarActivity {
 
     private void upload(final String uploadToken, final String domain) {
         if (this.uploadManager == null) {
-            this.uploadManager = new UploadManager();
+            //————http上传,指定zone的具体区域——
+            //Zone.zone0:华东
+            //Zone.zone1:华北
+            //Zone.zone2:华南
+            //Zone.zoneNa0:北美
+            //———http上传，自动识别上传区域——
+            //Zone.httpAutoZone
+            //———https上传，自动识别上传区域——
+            //Zone.httpsAutoZone
+
+            Configuration config = new Configuration.Builder()
+                    .chunkSize(256 * 1024)  //分片上传时，每片的大小。 默认256K
+                    .putThreshhold(512 * 1024)  // 启用分片上传阀值。默认512K
+                    .connectTimeout(10) // 链接超时。默认10秒
+                    .responseTimeout(60) // 服务器响应超时。默认60秒
+                    .recorder(null)  // recorder分片上传时，已上传片记录器。默认null
+                    .recorder(null, null)  // keyGen 分片上传时，生成标识符，用于片记录器区分是那个文件的上传记录
+                    .zone(Zone.zone2) // 设置区域，指定不同区域的上传域名、备用域名、备用IP。
+                    .build();
+            this.uploadManager = new UploadManager(config);
         }
         File uploadFile = new File(this.uploadFilePath);
         UploadOptions uploadOptions = new UploadOptions(null, null, false,


### PR DESCRIPTION
fix the problem :"error:incorrect region, please use up-z2.qiniu.com" using the ver:7.3.3 Android SDK 
使用新版的7.3.3的安卓sdk，会报错"error:incorrect region, please use up-z2.qiniu.com" ，需要配置UploadManager的config参数使用存储所在的zone。